### PR TITLE
Add slide links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 [ERC-4337](https://eips.ethereum.org/EIPS/eip-4337) account abstraction workshop for ETH Taipei 2023.
 
+## Slides
+
+* [Account Abstraction & ERC-4337](https://www.canva.com/design/DAFf5HAyHdA/aE72J5rZKlbPKoF1rIpWbQ/edit) by [@Alfred](https://github.com/ChiHaoLu)
+* [ERC-4337: Payment, Validation and Deployment](https://docs.google.com/presentation/d/1EF2JaSPBi3qqT6dEGge0xcAsEjSI50jXylkxEorFuso/edit?usp=sharing) by [@Nic](https://github.com/NIC619)
+* [ERC-4337: Limitations on Bundler](https://docs.google.com/presentation/d/1wMhlmhaV5K8FleywVCWe2Wgnb7KM4k6VScY2mNcPryI/edit?usp=sharing) by [@David](https://github.com/108356037)
+* [ERC-4337: Debugging Tips](https://docs.google.com/presentation/d/1aGIUsOETs3nvb_Et_Q2CTmuQDpN0d_M0iXx6ovnGVWw/edit?usp=sharing) by [@Nic](https://github.com/NIC619)
+
 ## Environment
 
 -   Foundry ([installation](https://book.getfoundry.sh/getting-started/installation))

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 
 ## Slides
 
-* [Account Abstraction & ERC-4337](https://www.canva.com/design/DAFf5HAyHdA/aE72J5rZKlbPKoF1rIpWbQ/edit) by [@Alfred](https://github.com/ChiHaoLu)
-* [ERC-4337: Payment, Validation and Deployment](https://docs.google.com/presentation/d/1EF2JaSPBi3qqT6dEGge0xcAsEjSI50jXylkxEorFuso/edit?usp=sharing) by [@Nic](https://github.com/NIC619)
-* [ERC-4337: Limitations on Bundler](https://docs.google.com/presentation/d/1wMhlmhaV5K8FleywVCWe2Wgnb7KM4k6VScY2mNcPryI/edit?usp=sharing) by [@David](https://github.com/108356037)
-* [ERC-4337: Debugging Tips](https://docs.google.com/presentation/d/1aGIUsOETs3nvb_Et_Q2CTmuQDpN0d_M0iXx6ovnGVWw/edit?usp=sharing) by [@Nic](https://github.com/NIC619)
+-   [Account Abstraction & ERC-4337](https://www.canva.com/design/DAFf5HAyHdA/aE72J5rZKlbPKoF1rIpWbQ/edit) by [@Alfred](https://github.com/ChiHaoLu)
+-   [ERC-4337: Payment, Validation and Deployment](https://docs.google.com/presentation/d/1EF2JaSPBi3qqT6dEGge0xcAsEjSI50jXylkxEorFuso/edit?usp=sharing) by [@Nic](https://github.com/NIC619)
+-   [ERC-4337: Limitations on Bundler](https://docs.google.com/presentation/d/1776RAo1QUwsU9pjbQW3t0IFyW7HorNCDTy9GDWkApFk/edit?usp=sharing) by [@David](https://github.com/108356037)
+-   [ERC-4337: Debugging Tips](https://docs.google.com/presentation/d/1aGIUsOETs3nvb_Et_Q2CTmuQDpN0d_M0iXx6ovnGVWw/edit?usp=sharing) by [@Nic](https://github.com/NIC619)
 
 ## Environment
 


### PR DESCRIPTION
Go to `add-slides` branch to see the rendering result:

https://github.com/consenlabs/ethtaipei2023-aa-workshop/tree/add-slides